### PR TITLE
fix sanity check that is broken by OCaml 4.02.x

### DIFF
--- a/ag_ob_run.ml
+++ b/ag_ob_run.ml
@@ -330,7 +330,7 @@ type t = {
 }
 
 let create () =
-  { { _a = None; _b = 42 } with _a = None }
+  { { _a = None; _b = Array.length Sys.argv } with _a = None }
 
 let test () =
   let r = create () in

--- a/ag_oj_run.ml
+++ b/ag_oj_run.ml
@@ -232,7 +232,7 @@ type t = {
 }
 
 let create () =
-  { { _a = None; _b = 42 } with _a = None }
+  { { _a = None; _b = Array.length Sys.argv } with _a = None }
 
 let test () =
   let r = create () in


### PR DESCRIPTION
OCaml 4.02.1 is smart enough to notice that the return value of `create ()` is a constant despite the use of `with`, so it pre-allocates it in the constant area (i.e. not the heap). Then the call to `Obj.set_field` breaks GC invariants and triggers an assertion failure in the debug version of the OCaml runtime. In the non-debug version it would typically lead to a segfault, either immediately (if the constant data is read-only) or much later (because the GC would trip on a dangling pointer). If you're lucky, it doesn't because the test data is not used in the rest of the program.

The solution is to make sure the record is not a compile-time constant, no matter how smart the compiler may be. For example, make it depend on `Sys.argv`.
