### PR TITLE
Fix tag_field error column number

### DIFF
--- a/atdgen.install
+++ b/atdgen.install
@@ -1,0 +1,4 @@
+bin: [
+  "src/atdgen.run"
+  "src/atdgen"
+]

--- a/opam
+++ b/opam
@@ -1,0 +1,16 @@
+opam-version: "1"
+maintainer: "martin@mjambon.com"
+homepage: "https://github.com/mjambon/atdgen"
+build: [
+  [make]
+  [make "install" "BINDIR=%{bin}%"]
+]
+remove: [
+    ["ocamlfind" "remove" "atdgen"]
+]
+depends: [
+  "ocamlfind"
+  "atd" {>= "1.1.0"}
+  "biniou" {>= "1.0.6"}
+  "yojson" {>= "1.2.0" }
+]

--- a/src/ag_oj_emit.ml
+++ b/src/ag_oj_emit.ml
@@ -1254,8 +1254,9 @@ and make_record_reader p type_annot loc a record_kind =
                 (* Defer parsing until we have read the whole record including
                    the constructor tag. *)
               `Line (sprintf "(let loc = raw_%s in" ocaml_fname);
+              `Line "let cnum = lb.Lexing.lex_curr_pos in";
               `Line "loc.Yojson.lnum <- p.Yojson.lnum;";
-              `Line "loc.Yojson.bol <- p.Yojson.bol;";
+              `Line "loc.Yojson.bol <- p.Yojson.bol - cnum;";
               `Line "loc.Yojson.fname <- p.Yojson.fname;";
               `Line "Bi_outbuf.clear p.Yojson.buf;";
               `Line "Yojson.Safe.buffer_json p lb;";


### PR DESCRIPTION
The previous implementation didn't take into account any previous JSON on the same line as the beginning of the tag field.

This patch uses a slight hack because it lies about the "beginning of line" which is only used for the exact calculation that is incorrect. The Yojson lexing state is only updated at newlines and does not track the column number. In order to take into account the present lexer offset when building the deferred buffer, we simply subtract the position in the line from the beginning of line global offset so that when this number is later subtracted, the error offset will be appropriately larger.

I also included some metadata files to make it easier to use opam 1.2.0's new pinning features.