### PR TITLE
Type conv option

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,4 @@
 PKG yojson atd
 
-B .
-S .
+B ./**
+S ./**

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ reinstall:
 test:
 	$(MAKE) -C test
 
+test-all:
+	$(MAKE) -C test test-all
+
 clean:
 	rm -f *~ util/*~ example/*~
 	$(MAKE) -C src clean

--- a/src/ag_main.ml
+++ b/src/ag_main.ml
@@ -78,7 +78,11 @@ let main () =
     let l = Str.split (Str.regexp " *, *\\| +") s in
     opens := List.rev_append l !opens
   in
+  let type_convs = ref [] in
   let options = [
+    "-type-conv", Arg.String (fun s ->
+      type_convs := Str.split (Str.regexp ",") s
+    ), "Type conv stuff";
     "-t", Arg.Unit (fun () ->
                       set_once "output type" mode `T;
                       set_once "no function definitions" with_fundefs false),
@@ -406,6 +410,7 @@ Recommended usage: %s (-t|-b|-j|-v|-dep|-list) example.atd" Sys.argv.(0) in
         let with_default default = function None -> default | Some x -> x in
 
         make_ocaml_files
+          ~type_convs: !type_convs
           ~opens
           ~with_typedefs: (with_default true !with_typedefs)
           ~with_create

--- a/src/ag_main.ml
+++ b/src/ag_main.ml
@@ -81,8 +81,12 @@ let main () =
   let type_convs = ref [] in
   let options = [
     "-type-conv", Arg.String (fun s ->
-      type_convs := Str.split (Str.regexp ",") s
-    ), "Type conv stuff";
+      type_convs := Str.split (Str.regexp ",") s),
+    "
+    GEN1,GEN2,...
+         Insert 'with GEN1, GEN2, ...' after OCaml type definitions for the
+         type-conv preprocessor
+    ";
     "-t", Arg.Unit (fun () ->
                       set_once "output type" mode `T;
                       set_once "no function definitions" with_fundefs false),

--- a/src/ag_ob_emit.ml
+++ b/src/ag_ob_emit.ml
@@ -1479,6 +1479,7 @@ let make_ocaml_files
     ~type_aliases
     ~force_defaults
     ~name_overlap
+    ~type_convs
     atd_file out =
   let ((head, m0), _) =
     match atd_file with
@@ -1511,7 +1512,7 @@ let make_ocaml_files
      m1 = original type definitions after dependency analysis
      m2 = monomorphic type definitions after dependency analysis *)
   let ocaml_typedefs =
-    Ag_ocaml.ocaml_of_atd ~target:`Biniou ~type_aliases (head, m1) in
+    Ag_ocaml.ocaml_of_atd ~type_convs ~target:`Biniou ~type_aliases (head, m1) in
   let defs = translate_mapping m2 in
   let header =
     let src =

--- a/src/ag_ocaml.ml
+++ b/src/ag_ocaml.ml
@@ -596,6 +596,12 @@ let append_ocamldoc_comment x doc =
         let comment = make_ocamldoc_comment y in
         Label ((x, label), comment)
 
+let format_type_conv_node node = function
+  | [] -> node
+  | converters ->
+    let converters = "with " ^ (String.concat ", " converters) in
+    Label ((node, label), make_atom converters)
+
 let rec format_module_item
     is_first (`Type def : ocaml_module_item) =
   let type_ = if is_first then "type" else "and" in

--- a/src/ag_ocaml.ml
+++ b/src/ag_ocaml.ml
@@ -744,12 +744,6 @@ let format_module_items is_rec (l : ocaml_module_body) =
           List.map (fun x -> format_module_item false x) l
     | [] -> []
 
-let format_module_body is_rec (l : ocaml_module_body) =
-  List (
-    ("", "", "", rlist),
-    format_module_items is_rec l
-  )
-
 let format_module_bodies (l : (bool * ocaml_module_body) list) =
   List.flatten (List.map (fun (is_rec, x) -> format_module_items is_rec x) l)
 

--- a/src/ag_oj_emit.ml
+++ b/src/ag_oj_emit.ml
@@ -1722,6 +1722,7 @@ let make_ocaml_files
     ~force_defaults
     ~preprocess_input
     ~name_overlap
+    ~type_convs
     atd_file out =
   let ((head, m0), _) =
     match atd_file with
@@ -1753,7 +1754,7 @@ let make_ocaml_files
      m1 = original type definitions after dependency analysis
      m2 = monomorphic type definitions after dependency analysis *)
   let ocaml_typedefs =
-    Ag_ocaml.ocaml_of_atd ~target:`Json ~type_aliases (head, m1) in
+    Ag_ocaml.ocaml_of_atd ~type_convs ~target:`Json ~type_aliases (head, m1) in
   let defs = translate_mapping m2 in
   let header =
     let src =

--- a/src/ag_ov_emit.ml
+++ b/src/ag_ov_emit.ml
@@ -472,6 +472,7 @@ let make_ocaml_files
     ~type_aliases
     ~force_defaults
     ~name_overlap
+    ~type_convs
     atd_file out =
   let ((head, m0), _) =
     match atd_file with
@@ -504,7 +505,7 @@ let make_ocaml_files
      m1 = original type definitions after dependency analysis
      m2 = monomorphic type definitions after dependency analysis *)
   let ocaml_typedefs =
-    Ag_ocaml.ocaml_of_atd ~target:`Validate ~type_aliases (head, m1) in
+    Ag_ocaml.ocaml_of_atd ~type_convs ~target:`Validate ~type_aliases (head, m1) in
   let defs = translate_mapping m2 in
   let header =
     let src =

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -31,3 +31,6 @@ testjstd.ml
 testjstd.mli
 testv.ml
 testv.mli
+test3j_*.ml*
+test_type_conv_*.ml*
+test_atdgen_type_conv

--- a/test/Makefile
+++ b/test/Makefile
@@ -30,6 +30,7 @@ really-test:
 	$(ATDGEN) -o-name-overlap -t test5.atd
 	$(ATDGEN) -o-name-overlap -j test5.atd
 	$(ATDGEN) -o-name-overlap -b test5.atd
+	$(ATDGEN) -t test_type_conv.atd -type-conv sexp -open "Sexplib.Std"
 	ocamlfind ocamlc -c -package atdgen \
 		test5_t.mli test5_t.ml test5_j.mli test5_j.ml
 	ocamlfind ocamlc -c -package atdgen \
@@ -64,6 +65,20 @@ really-test:
 		test3j_t.mli test4.mli test4j.mli testv.mli
 	./test_atdgen
 
+.PHONY: test-all
+test-all: really-test
+	ocamlfind ocamlc -c -g -syntax camlp4o -package camlp4 \
+	  -package sexplib -package sexplib.syntax \
+	  test_type_conv_t.mli
+	ocamlfind ocamlopt -c -g -syntax camlp4o -package camlp4 \
+	  -package sexplib -package sexplib.syntax \
+	  test_type_conv_t.ml
+	ocamlfind ocamlopt -c -g test_atdgen_type_conv.ml -package atdgen -package sexplib
+	ocamlfind ocamlopt -o test_atdgen_type_conv$(EXE) -g -linkpkg \
+	  -syntax camlp4o -package camlp4 \
+	  -package sexplib -package sexplib.syntax \
+	  test_type_conv_t.cmx test_atdgen_type_conv.cmx
+	./test_atdgen_type_conv
 
 # Benchmarking and more testing
 

--- a/test/test_atdgen_type_conv.ml
+++ b/test/test_atdgen_type_conv.ml
@@ -1,0 +1,19 @@
+open Sexplib.Std
+
+let my_record = Test_type_conv_t.({ fst=123; snd="testing" })
+
+let cmrs : (float Test_type_conv_t.contains_my_record) list =
+  let open Test_type_conv_t in
+  [ `C1 123
+  ; `C2 123.0
+  ; `C3 my_record ]
+
+let sexps =
+  [my_record |> Test_type_conv_t.sexp_of_my_record] @
+  (List.map (Test_type_conv_t.sexp_of_contains_my_record sexp_of_float) cmrs)
+
+let () =
+  sexps
+  |> sexp_of_list (fun x -> x)
+  |> Sexplib.Sexp.to_string
+  |> print_endline

--- a/test/test_type_conv.atd
+++ b/test/test_type_conv.atd
@@ -1,0 +1,13 @@
+<doc text="testing -type-conv.">
+
+type my_record = {
+  fst: int;
+  snd: string;
+}
+
+
+type 'a contains_my_record = [
+  | C1 of int
+  | C2 of 'a
+  | C3 of my_record
+]


### PR DESCRIPTION
First attempt for #23 with the goal of being as un-intrusive as possible or at least until I get some feedback.

One question:

The `-type-conv` option probably doesn't make sense without some corresponding modules being opened e.g. `Core.Std` or `Sexplib.Conv`. Does it make sense to warn the user about this?

@mjambon thanks for the pointers in #23 and I've tried to follow your contribution guide although I don't think much of atdgen follows your formatting rules.