### PR TITLE
Allow bulk insertion of ppx_deriving annotations

### DIFF
--- a/src/ag_ob_emit.ml
+++ b/src/ag_ob_emit.ml
@@ -1479,7 +1479,7 @@ let make_ocaml_files
     ~type_aliases
     ~force_defaults
     ~name_overlap
-    ~type_convs
+    ~pp_convs
     atd_file out =
   let ((head, m0), _) =
     match atd_file with
@@ -1512,7 +1512,7 @@ let make_ocaml_files
      m1 = original type definitions after dependency analysis
      m2 = monomorphic type definitions after dependency analysis *)
   let ocaml_typedefs =
-    Ag_ocaml.ocaml_of_atd ~type_convs ~target:`Biniou ~type_aliases (head, m1) in
+    Ag_ocaml.ocaml_of_atd ~pp_convs ~target:`Biniou ~type_aliases (head, m1) in
   let defs = translate_mapping m2 in
   let header =
     let src =

--- a/src/ag_ocaml.ml
+++ b/src/ag_ocaml.ml
@@ -597,13 +597,17 @@ let append_ocamldoc_comment x doc =
         let comment = make_ocamldoc_comment y in
         Label ((x, label), comment)
 
-let format_type_conv_node node = function
-  | [] -> node
+let format_pp_conv_node node = function
+  | `Camlp4 []
+  | `Ppx [] -> node
   | converters ->
-    let converters = "with " ^ (String.concat ", " converters) in
+    let converters =
+      match converters with
+      | `Ppx cs -> "[@@deriving " ^ (String.concat ", " cs) ^ "]"
+      | `Camlp4 cs -> "with " ^ (String.concat ", " cs) in
     Label ((node, label), make_atom converters)
 
-let rec format_module_item type_convs
+let rec format_module_item pp_convs
     is_first (`Type def : ocaml_module_item) =
   let type_ = if is_first then "type" else "and" in
   let s, param = def.o_def_name in
@@ -646,7 +650,7 @@ let rec format_module_item type_convs
             format_type_expr t
           )
   in
-  format_type_conv_node (prepend_ocamldoc_comment doc part123) type_convs
+  format_pp_conv_node (prepend_ocamldoc_comment doc part123) pp_convs
 
 
 and prepend_type_param l tl =
@@ -744,15 +748,15 @@ and format_variant kind (s, o, doc) =
   in
   append_ocamldoc_comment variant doc
 
-let format_module_items type_convs is_rec (l : ocaml_module_body) =
+let format_module_items pp_convs is_rec (l : ocaml_module_body) =
   match l with
       x :: l ->
-        format_module_item type_convs true x ::
-          List.map (fun x -> format_module_item type_convs false x) l
+        format_module_item pp_convs true x ::
+          List.map (fun x -> format_module_item pp_convs false x) l
     | [] -> []
 
-let format_module_bodies type_conv (l : (bool * ocaml_module_body) list) =
-  List.flatten (List.map (fun (is_rec, x) -> format_module_items type_conv is_rec x) l)
+let format_module_bodies pp_conv (l : (bool * ocaml_module_body) list) =
+  List.flatten (List.map (fun (is_rec, x) -> format_module_items pp_conv is_rec x) l)
 
 let format_head (loc, an) =
   match Ag_doc.get_doc loc an with
@@ -766,14 +770,14 @@ let format_all l =
 let ocaml_of_expr x : string =
   Easy_format.Pretty.to_string (format_type_expr x)
 
-let ocaml_of_atd ?(type_convs=[]) ~target ~type_aliases
+let ocaml_of_atd ?(pp_convs=`Ppx []) ~target ~type_aliases
     (head, (l : (bool * module_body) list)) : string =
   let head = format_head head in
   let bodies =
     List.map (fun (is_rec, m) ->
                 (is_rec, map_module ~target ~type_aliases m)) l
   in
-  let body = format_module_bodies type_convs bodies in
+  let body = format_module_bodies pp_convs bodies in
   let x = format_all (head @ body) in
   Easy_format.Pretty.to_string x
 

--- a/src/ag_oj_emit.ml
+++ b/src/ag_oj_emit.ml
@@ -1722,7 +1722,7 @@ let make_ocaml_files
     ~force_defaults
     ~preprocess_input
     ~name_overlap
-    ~type_convs
+    ~pp_convs
     atd_file out =
   let ((head, m0), _) =
     match atd_file with
@@ -1754,7 +1754,7 @@ let make_ocaml_files
      m1 = original type definitions after dependency analysis
      m2 = monomorphic type definitions after dependency analysis *)
   let ocaml_typedefs =
-    Ag_ocaml.ocaml_of_atd ~type_convs ~target:`Json ~type_aliases (head, m1) in
+    Ag_ocaml.ocaml_of_atd ~pp_convs ~target:`Json ~type_aliases (head, m1) in
   let defs = translate_mapping m2 in
   let header =
     let src =

--- a/src/ag_ov_emit.ml
+++ b/src/ag_ov_emit.ml
@@ -473,7 +473,7 @@ let make_ocaml_files
     ~type_aliases
     ~force_defaults
     ~name_overlap
-    ~type_convs
+    ~pp_convs
     atd_file out =
   let ((head, m0), _) =
     match atd_file with
@@ -506,7 +506,7 @@ let make_ocaml_files
      m1 = original type definitions after dependency analysis
      m2 = monomorphic type definitions after dependency analysis *)
   let ocaml_typedefs =
-    Ag_ocaml.ocaml_of_atd ~type_convs ~target:`Validate ~type_aliases (head, m1) in
+    Ag_ocaml.ocaml_of_atd ~pp_convs ~target:`Validate ~type_aliases (head, m1) in
   let defs = translate_mapping m2 in
   let header =
     let src =


### PR DESCRIPTION
New option -deriving-conv which is just like -type-conv except for
ppx_deriving plugins.