### PR TITLE
(temporary) fix for 4.03 segfault

### DIFF
--- a/src/ag_main.ml
+++ b/src/ag_main.ml
@@ -54,8 +54,8 @@ let parse_ocaml_version () =
   else
     None
 
-let get_default_name_overlap () =
-  match parse_ocaml_version () with
+let get_default_name_overlap ocaml_version =
+  match ocaml_version with
   | Some (major, minor) when major < 4 -> false
   | Some (4, 0) -> false
   | _ -> true
@@ -77,7 +77,8 @@ let main () =
   let unknown_field_handler = ref None in
   let constr_mismatch_handler = ref None in
   let type_aliases = ref None in
-  let name_overlap = ref (get_default_name_overlap ()) in
+  let ocaml_version = parse_ocaml_version () in
+  let name_overlap = ref (get_default_name_overlap ocaml_version) in
   let set_opens s =
     let l = Str.split (Str.regexp " *, *\\| +") s in
     opens := List.rev_append l !opens
@@ -435,6 +436,7 @@ Recommended usage: %s (-t|-b|-j|-v|-dep|-list) example.atd" Sys.argv.(0) in
           ~pos_lnum: !pos_lnum
           ~type_aliases
           ~force_defaults
+          ~ocaml_version
           ~name_overlap: !name_overlap
           atd_file ocaml_prefix
 

--- a/src/ag_ob_emit.ml
+++ b/src/ag_ob_emit.ml
@@ -738,7 +738,11 @@ let study_record ~ocaml_version deref fields =
           match default with
               None ->
                 assert (not opt);
-                "Obj.magic 0.0"
+                begin match ocaml_version with
+                  | Some (maj, min) when (maj > 4 || maj = 4 && min >= 3) ->
+                      "Obj.magic (Sys.opaque_identity 0.0)"
+                  | _ -> "Obj.magic 0.0"
+                end
             | Some s ->
                 s
         in

--- a/src/ag_ob_emit.ml
+++ b/src/ag_ob_emit.ml
@@ -1479,6 +1479,7 @@ let make_ocaml_files
     ~type_aliases
     ~force_defaults
     ~name_overlap
+    ~ocaml_version
     ~pp_convs
     atd_file out =
   let ((head, m0), _) =

--- a/src/ag_oj_emit.ml
+++ b/src/ag_oj_emit.ml
@@ -741,8 +741,11 @@ and make_record_writer p a record_kind =
     `Line "Bi_outbuf.add_char ob '}';";
   ]
 
-let study_record deref fields =
-  let unset_field_value = "Obj.magic 0.0" in
+let study_record p fields =
+  let unset_field_value = match p.ocaml_version with
+    | Some (maj, min) when (maj > 4 || maj = 4 && min >= 3) ->
+      "Obj.magic (Sys.opaque_identity 0.0)"
+    | _ -> "Obj.magic 0.0" in
 
   let _, field_assignments =
     Array.fold_right (fun field (i, field_assignments) ->
@@ -1235,7 +1238,7 @@ and make_deconstructed_reader p loc fields set_bit =
 and make_record_reader p type_annot loc a record_kind =
   let fields = get_fields p a in
   let init_fields, init_bits, set_bit, check_bits, create_record =
-    study_record p.deref fields
+    study_record p fields
   in
 
   let read_field =

--- a/src/ag_oj_emit.ml
+++ b/src/ag_oj_emit.ml
@@ -34,6 +34,8 @@ type param = {
   preprocess_input : string option;
     (* intended for UTF-8 validation *)
 
+  ocaml_version: (int * int) option;
+
 }
 
 
@@ -1617,6 +1619,7 @@ let get_let ~is_rec ~is_first =
 let make_ocaml_json_impl
     ~std ~unknown_field_handler ~constr_mismatch_handler
     ~with_create ~force_defaults ~preprocess_input ~original_types
+    ~ocaml_version
     buf deref defs =
   let p = {
     deref = deref;
@@ -1625,6 +1628,7 @@ let make_ocaml_json_impl
     constr_mismatch_handler = constr_mismatch_handler;
     force_defaults = force_defaults;
     preprocess_input;
+    ocaml_version;
   } in
   let ll =
     List.map (
@@ -1692,6 +1696,7 @@ let make_ml
     ~header ~opens ~with_typedefs ~with_create ~with_fundefs
     ~std ~unknown_field_handler ~constr_mismatch_handler
     ~force_defaults ~preprocess_input ~original_types
+    ~ocaml_version
     ocaml_typedefs deref defs =
   let buf = Buffer.create 1000 in
   bprintf buf "%s\n" header;
@@ -1704,6 +1709,7 @@ let make_ml
     make_ocaml_json_impl
       ~std ~unknown_field_handler ~constr_mismatch_handler
       ~with_create ~force_defaults ~preprocess_input ~original_types
+      ~ocaml_version
       buf deref defs;
   Buffer.contents buf
 
@@ -1722,6 +1728,7 @@ let make_ocaml_files
     ~force_defaults
     ~preprocess_input
     ~name_overlap
+    ~ocaml_version
     ~pp_convs
     atd_file out =
   let ((head, m0), _) =
@@ -1772,6 +1779,7 @@ let make_ocaml_files
     make_ml ~header ~opens ~with_typedefs ~with_create ~with_fundefs
       ~std ~unknown_field_handler ~constr_mismatch_handler
       ~force_defaults ~preprocess_input ~original_types
+      ~ocaml_version
       ocaml_typedefs (Ag_mapping.make_deref defs) defs
   in
   Ag_ox_emit.write_ocaml out mli ml

--- a/src/ag_ov_emit.ml
+++ b/src/ag_ov_emit.ml
@@ -473,6 +473,7 @@ let make_ocaml_files
     ~type_aliases
     ~force_defaults
     ~name_overlap
+    ~ocaml_version
     ~pp_convs
     atd_file out =
   let ((head, m0), _) =


### PR DESCRIPTION
The following series of commits implements the work-around discussing in #45, using `Obj.magic (Sys.opaque_identity 0.0)` instead of `Obj.magic 0.0`. I believe that the code is still wrong, but it segfaults strictly less¹. The long-term solution would be to use option references for field, but it is a more invasive change that I'd rather let @mjambon do, if he has the time before the next time it breaks.

¹: without this patchset, atdgen's testsuite segfaults under 4.03 (with or without flambda), with the patchset it works. See the long comment in the "compiler internal" part of the testsuite for an attempt at an explanation.