### PR TITLE
Add mli for a module

### DIFF
--- a/src/ag_ox_emit.mli
+++ b/src/ag_ox_emit.mli
@@ -1,0 +1,32 @@
+type 'a expr = (Ag_ocaml.atd_ocaml_repr, 'a) Ag_mapping.mapping
+type 'a def = (Ag_ocaml.atd_ocaml_repr, 'a) Ag_mapping.def
+type 'a grouped_defs = (bool * 'a def list) list
+
+val get_full_type_name : (_, _) Ag_mapping.def -> string
+
+val is_exportable : (_, _) Ag_mapping.def -> bool
+
+val make_record_creator
+  : ((Ag_ocaml.atd_ocaml_repr, 'a) Ag_mapping.mapping
+     -> (Ag_ocaml.atd_ocaml_repr, 'b) Ag_mapping.mapping)
+  -> (Ag_ocaml.atd_ocaml_repr, 'a) Ag_mapping.def
+  -> string * string
+
+val opt_annot : string option -> string -> string
+
+val opt_annot_def : string option -> string -> string
+
+val insert_annot : string option -> string
+
+val get_type_constraint
+  : original_types:(string, string * int) Hashtbl.t
+  -> ('a, 'b) Ag_mapping.def
+  -> string
+
+val is_function : Ag_indent.t list -> bool
+
+val needs_type_annot : _ expr -> bool
+
+val check : _ grouped_defs -> unit
+
+val write_ocaml : [< `Files of string | `Stdout ] -> string -> string -> unit


### PR DESCRIPTION
I end up referencing the atdgen source pretty often. But the lack of mli's
makes understanding the code a bit tougher than it has to be. It's not clear
what is only used internally and what is public. Also, having all the type
signatures in 1 place is useful when reading.

I'm not sure how you feel about mli's but I figured that even if you don't like
the boilerplate they introduce, atdgen's source doesn't change enough for this to
be a problem.

Anyway, if this RP is accepted, I will slowly add mre mli's as I'm reading the
source.