### PR TITLE
<json untyped>

### DIFF
--- a/src/ag_json.ml
+++ b/src/ag_json.ml
@@ -7,7 +7,7 @@ type json_float = [ `Float of int option (* max decimal places *)
 
 type json_list = [ `Array | `Object ]
 
-type json_variant = { json_cons : string }
+type json_variant = { json_cons : string option }
 
 type json_field = {
   json_fname  : string;           (* <json name=...> *)
@@ -76,3 +76,6 @@ let get_json_fname default an =
 
 let get_json_tag_field an =
   Atd_annot.get_field (fun s -> Some (Some s)) None ["json"] "tag_field" an
+
+let get_json_untyped an =
+  Atd_annot.get_flag ["json"] "untyped" an

--- a/src/ag_json.mli
+++ b/src/ag_json.mli
@@ -4,7 +4,7 @@ type json_float = [ `Float of int option (* max decimal places *)
 
 type json_list = [ `Array | `Object ]
 
-type json_variant = { json_cons : string }
+type json_variant = { json_cons : string option }
 
 type json_field = {
   json_fname  : string;           (* <json name=...> *)
@@ -40,3 +40,5 @@ val get_json_cons : string -> Atd_annot.t -> string
 val get_json_fname : string -> Atd_annot.t -> string
 
 val get_json_tag_field : Atd_annot.t -> string option
+
+val get_json_untyped : Atd_annot.t -> bool

--- a/src/ag_oj_mapping.ml
+++ b/src/ag_oj_mapping.ml
@@ -113,11 +113,12 @@ and mapping_of_variant = function
           ocaml_vdoc = doc;
         }
       in
-      let json_cons = Ag_json.get_json_cons s an in
       let json_t =
-        `Variant {
-          Ag_json.json_cons = json_cons;
-        }
+        if Ag_json.get_json_untyped an
+        then `Variant { Ag_json.json_cons = None; }
+        else
+          let json_cons = Ag_json.get_json_cons s an in
+          `Variant { Ag_json.json_cons = Some json_cons; }
       in
       let arg =
         match o with

--- a/src/ag_string_match.ml
+++ b/src/ag_string_match.ml
@@ -205,6 +205,10 @@ let make_ocaml_expr_factored
           in
           exit_expr, catch
   in
+  let cases = List.(rev (fold_left (fun list -> function
+    | (Some s, x) -> (s, x)::list
+    | (None, _) -> list
+  ) [] cases)) in
   match cases with
       [] -> error_expr
     | l ->
@@ -221,7 +225,7 @@ let test () =
   in
   let cases =
     List.map
-      (fun s -> (s, [ `Line (sprintf "Some `Case_%s" s) ]))
+      (fun s -> (Some s, [ `Line (sprintf "Some `Case_%s" s) ]))
       l
   in
   let expr =
@@ -238,11 +242,13 @@ let make_ocaml_expr_naive
     ?(len_id = "len")
     ~error_expr
     cases =
-  let map (s, expr) =
-    `Inline [
-      `Line (sprintf "| %S ->" s);
-      `Block expr;
-    ]
+  let map = function
+    | (Some s, expr) ->
+        `Inline [
+          `Line (sprintf "| %S ->" s);
+          `Block expr;
+        ]
+    | (None, _expr) -> `Inline []
   in
   [
     `Line (sprintf "match %s with" string_id);

--- a/src/ag_string_match.mli
+++ b/src/ag_string_match.mli
@@ -33,14 +33,14 @@ val make_ocaml_expr_factored :
   ?len_id: string ->
   ?exit_with: exit_with ->
   error_expr: Ag_indent.t list ->
-  (string * Ag_indent.t list) list -> Ag_indent.t list
+  (string option * Ag_indent.t list) list -> Ag_indent.t list
 
 val make_ocaml_expr_naive :
   ?string_id: string ->
   ?pos_id: string ->
   ?len_id: string ->
   error_expr: Ag_indent.t list ->
-  (string * Ag_indent.t list) list -> Ag_indent.t list
+  (string option * Ag_indent.t list) list -> Ag_indent.t list
 
 val make_ocaml_expr :
   optimized: bool ->
@@ -49,7 +49,7 @@ val make_ocaml_expr :
   ?len_id: string ->
   ?exit_with: exit_with ->
   error_expr: Ag_indent.t list ->
-  (string * Ag_indent.t list) list -> Ag_indent.t list
+  (string option * Ag_indent.t list) list -> Ag_indent.t list
 
 
 val make_ocaml_int_mapping :
@@ -60,7 +60,7 @@ val make_ocaml_int_mapping :
   error_expr1: Ag_indent.t list ->
   ?error_expr2: Ag_indent.t list ->
   ?int_id: string ->
-  (string * Ag_indent.t list) list ->
+  (string option * Ag_indent.t list) list ->
 
   (Ag_indent.t list * Ag_indent.t list)
     (*

--- a/test/test3j.atd
+++ b/test/test3j.atd
@@ -106,3 +106,22 @@ type chained_constr_record = {
   second_tag <json tag_field="first_tag"> : inter_constr;
   chained_constr <json tag_field="second_tag"> : constr;
 }
+
+type fallback_constr = [
+| A <json name="a">
+| Other <json untyped> of (string * json option)
+]
+
+type fallback_constr_record = {
+  fallback_constr <json tag_field="tag"> : fallback_constr;
+}
+
+type empty_constr = [
+  | A <json name="">
+  | Other <json untyped> of (string * json option)
+]
+
+type empty_constr_record = {
+  empty : empty_constr;
+  empty_constr <json tag_field="tag"> : empty_constr;
+}

--- a/test/test3j.atd
+++ b/test/test3j.atd
@@ -113,6 +113,7 @@ type fallback_constr = [
 ]
 
 type fallback_constr_record = {
+  ~tag <ocaml default="\"unknown\"">: string;
   fallback_constr <json tag_field="tag"> : fallback_constr;
 }
 

--- a/test/test_atdgen_main.ml
+++ b/test/test_atdgen_main.ml
@@ -777,6 +777,88 @@ let test_json_constr_chained () =
   let s'= Yojson.Safe.to_string j in
   check (s = s')
 
+let test_json_constr_fallback_tag () =
+  section "json constructors fallback tag";
+  let x = {
+    Test3j_t.fallback_constr = `A;
+  } in
+  let s = Test3j_j.string_of_fallback_constr_record x in
+  let x'= Test3j_j.fallback_constr_record_of_string s in
+  check (x = x');
+
+  let j = `Assoc ["tag", `String "a"] in
+  let s' = Yojson.Safe.to_string j in
+  check (s = s');
+
+  let x = {
+    Test3j_t.fallback_constr = `Other ("b", None);
+  } in
+  let s = Test3j_j.string_of_fallback_constr_record x in
+  let x'= Test3j_j.fallback_constr_record_of_string s in
+  check (x = x');
+
+  let j = `Assoc ["tag", `String "b"] in
+  let s' = Yojson.Safe.to_string j in
+  check (s = s');
+
+  let x = {
+    Test3j_t.fallback_constr = `Other ("b", Some `Null);
+  } in
+  let s = Test3j_j.string_of_fallback_constr_record x in
+  let x'= Test3j_j.fallback_constr_record_of_string s in
+  check (x = x');
+
+  let j = `Assoc [
+    "fallback_constr", `Null;
+    "tag", `String "b";
+  ] in
+  let s' = Yojson.Safe.to_string j in
+  check (s = s')
+
+let test_json_constr_fallback_empty () =
+  section "json constructors fallback empty";
+  let x = {
+    Test3j_t.empty = `A;
+    empty_constr = `Other ("foo", None);
+  } in
+  let s = Test3j_j.string_of_empty_constr_record x in
+  let x'= Test3j_j.empty_constr_record_of_string s in
+  check (x = x');
+
+  let j = `Assoc ["empty", `String ""; "tag", `String "foo"] in
+  let s' = Yojson.Safe.to_string j in
+  check (s = s');
+
+  let x = {
+    Test3j_t.empty = `Other ("baz", Some `Null);
+    empty_constr = `A;
+  } in
+  let s = Test3j_j.string_of_empty_constr_record x in
+  let x'= Test3j_j.empty_constr_record_of_string s in
+  check (x = x');
+
+  let j = `Assoc [
+    "empty", `List [`String "baz"; `Null];
+    "tag", `String "";
+  ] in
+  let s' = Yojson.Safe.to_string j in
+  check (s = s');
+
+  let x = {
+    Test3j_t.empty = `Other ("baz", None);
+    empty_constr = `A;
+  } in
+  let s = Test3j_j.string_of_empty_constr_record x in
+  let x'= Test3j_j.empty_constr_record_of_string s in
+  check (x = x');
+
+  let j = `Assoc [
+    "empty", `String "baz";
+    "tag", `String "";
+  ] in
+  let s' = Yojson.Safe.to_string j in
+  check (s = s')
+
 let test_wrapping_ints () =
   section "ocaml wrapping - ints";
   let x = Test_lib.Natural.wrap 7 in
@@ -861,6 +943,8 @@ let all_tests = [
   test_json_constr_default;
   test_json_constr_default_implicit;
   test_json_constr_chained;
+  test_json_constr_fallback_tag;
+  test_json_constr_fallback_empty;
   test_wrapping_ints;
   test_double_wrapping;
   test_wrapping_with_validation;

--- a/test/test_atdgen_main.ml
+++ b/test/test_atdgen_main.ml
@@ -780,6 +780,7 @@ let test_json_constr_chained () =
 let test_json_constr_fallback_tag () =
   section "json constructors fallback tag";
   let x = {
+    Test3j_t.tag = "a";
     Test3j_t.fallback_constr = `A;
   } in
   let s = Test3j_j.string_of_fallback_constr_record x in
@@ -790,7 +791,11 @@ let test_json_constr_fallback_tag () =
   let s' = Yojson.Safe.to_string j in
   check (s = s');
 
+  let s' = Test3j_j.string_of_fallback_constr_record x' in
+  check (s = s');
+
   let x = {
+    Test3j_t.tag = "b";
     Test3j_t.fallback_constr = `Other ("b", None);
   } in
   let s = Test3j_j.string_of_fallback_constr_record x in
@@ -801,19 +806,40 @@ let test_json_constr_fallback_tag () =
   let s' = Yojson.Safe.to_string j in
   check (s = s');
 
+  let s' = Test3j_j.string_of_fallback_constr_record x' in
+  check (s = s');
+
   let x = {
-    Test3j_t.fallback_constr = `Other ("b", Some `Null);
+    Test3j_t.tag = "b";
+    Test3j_t.fallback_constr = `Other ("b", Some (`Assoc []));
   } in
   let s = Test3j_j.string_of_fallback_constr_record x in
   let x'= Test3j_j.fallback_constr_record_of_string s in
   check (x = x');
 
   let j = `Assoc [
-    "fallback_constr", `Null;
     "tag", `String "b";
+    "fallback_constr", `Assoc [];
   ] in
   let s' = Yojson.Safe.to_string j in
-  check (s = s')
+  check (s = s');
+
+  let s' = Test3j_j.string_of_fallback_constr_record x' in
+  check (s = s');
+
+  let j = `Assoc [
+    "fallback_constr", `Int 123;
+  ] in
+  let s = Yojson.Safe.to_string j in
+  let x = Test3j_j.fallback_constr_record_of_string s in
+  let s'= Test3j_j.string_of_fallback_constr_record x in
+  check (s = s');
+
+  let x'= {
+    Test3j_t.tag = "unknown";
+    Test3j_t.fallback_constr = `Other ("unknown", Some (`Int 123));
+  } in
+  check (x = x')
 
 let test_json_constr_fallback_empty () =
   section "json constructors fallback empty";


### PR DESCRIPTION
This implements the `<json untyped>` variant annotation for variant fallback parsing. Both `tag_field` and regular variant encodings can use `<json untyped>`. Only one `<json untyped>` annotation can be used for a given type. The constructor which is annotated with `<json untyped>` **must** have argument type `string * json option`. These constraints are enforced during the ATD parse in a new check phase.

This PR requires mjambon/atd#8 for the checking phase implemented in 1236e29e47832f735407db8986881dfbef87eb8c. This PR fixes #54.

I'm happy to answer questions and write documentation (if you tell me where to put it/what style to use for integration). I'd really appreciate a review and release with this feature as we are very keen to use it in ocaml-github.

Thanks!